### PR TITLE
maintenance: Drop datetime.now() - use time zone aware datetime objects (UTC)

### DIFF
--- a/.github/workflows/pre-tests.yaml
+++ b/.github/workflows/pre-tests.yaml
@@ -10,9 +10,14 @@ jobs:
     name: Preliminary checks
     runs-on: ubuntu-latest
     steps:
-      - 
-        name: Checkout code
+      - name: Checkout code
         uses: actions/checkout@v4
-      -
-        name: Run linter, formatter, and type checker
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Run linter, formatter, and type checker
         uses: ./.github/actions/pre-test/

--- a/.github/workflows/pre-tests.yaml
+++ b/.github/workflows/pre-tests.yaml
@@ -9,6 +9,7 @@ jobs:
   lint-format-type:
     name: Preliminary checks
     runs-on: ubuntu-latest
+    environment: demo
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/tests/crud/test_base.py
+++ b/tests/crud/test_base.py
@@ -70,7 +70,7 @@ class TestBaseRepository:
 
         # Validation
         assert stored_object is not None
-        assert stored_object.model_dump() == test_record.model_dump()
+        assert stored_object.model_dump() == created_object.model_dump()
 
         # Clean-up
         ...
@@ -82,14 +82,17 @@ class TestBaseRepository:
         x = 1
         y = 10
         test_records = []
+        created_objects = []
 
         for _ in range(15):
             test_record = DummyModel(a=x, b=y)
             test_records.append(test_record)
-            self.test_crud_repository.add(
+
+            created_object = self.test_crud_repository.add(
                 db=self.test_db,
                 input_object=test_record,
             )
+            created_objects.append(created_object.model_copy(deep=True))
             x += 1
             y += 1
 
@@ -103,8 +106,9 @@ class TestBaseRepository:
         # Validation
         assert stored_objects is not None
         assert 5 == len(stored_objects)
-        for test_record, stored_object in zip(test_records[-5:], stored_objects):
-            assert stored_object.model_dump() == test_record.model_dump()
+        for created_object, stored_object in zip(created_objects[-5:], stored_objects):
+            assert stored_object is not None
+            assert stored_object.model_dump() == created_object.model_dump()
 
         # Clean-up
         ...

--- a/ums/core/security.py
+++ b/ums/core/security.py
@@ -21,9 +21,11 @@ def get_password_hash(password: str):
 def create_access_token(data: dict, expire_delta: timedelta | None = None):
     to_encode = data.copy()
     if expire_delta:
-        expire = datetime.utcnow() + expire_delta
+        expire = datetime.now() + expire_delta
     else:
-        expire = datetime.utcnow() + timedelta(minutes=5)
+        expire = datetime.now() + timedelta(
+            minutes=security_settings.access_token_expire_minutes
+        )
 
     to_encode.update({"exp": expire})
 

--- a/ums/crud/base.py
+++ b/ums/crud/base.py
@@ -6,7 +6,16 @@ from typing import Type, Generic, TypeVar, Any
 from pydantic import BaseModel
 import uuid
 from loguru import logger
-from datetime import datetime, UTC
+from datetime import datetime
+import sys
+from datetime import datetime
+
+if sys.version_info > (3, 11):
+    from datetime import UTC
+else:
+    from datetime import timezone
+
+    UTC = timezone.utc
 
 from fastapi.encoders import jsonable_encoder
 from sqlmodel import Session, select, SQLModel

--- a/ums/crud/base.py
+++ b/ums/crud/base.py
@@ -6,7 +6,7 @@ from typing import Type, Generic, TypeVar, Any
 from pydantic import BaseModel
 import uuid
 from loguru import logger
-from datetime import datetime
+from datetime import datetime, UTC
 
 from fastapi.encoders import jsonable_encoder
 from sqlmodel import Session, select, SQLModel
@@ -136,7 +136,7 @@ class BaseRepository(BaseModel, Generic[ModelType]):
         for key, value in update_data.items():
             setattr(db_obj, key, value)
 
-        setattr(db_obj, "updated_at", datetime.utcnow())
+        setattr(db_obj, "updated_at", datetime.now(tz=UTC))
 
         db.add(db_obj)
         db.commit()
@@ -154,7 +154,7 @@ class BaseRepository(BaseModel, Generic[ModelType]):
         if target_object:
             target_object.is_deleted = True
             target_object.is_active = False
-            target_object.deleted_at = datetime.utcnow()
+            target_object.deleted_at = datetime.now(tz=UTC)
             db.add(target_object)
             db.commit()
 

--- a/ums/crud/group/repository.py
+++ b/ums/crud/group/repository.py
@@ -2,7 +2,15 @@ from typing import Type, Any
 from sqlmodel import Session
 import uuid
 from enum import Enum
-from datetime import datetime, UTC
+import sys
+from datetime import datetime
+
+if sys.version_info > (3, 11):
+    from datetime import UTC
+else:
+    from datetime import timezone
+
+    UTC = timezone.utc
 
 from ums.crud.base import BaseRepository, CreateSchema, UpdateSchema
 from ums.crud.group.validation import GroupValidator

--- a/ums/crud/group/repository.py
+++ b/ums/crud/group/repository.py
@@ -2,7 +2,7 @@ from typing import Type, Any
 from sqlmodel import Session
 import uuid
 from enum import Enum
-from datetime import datetime
+from datetime import datetime, UTC
 
 from ums.crud.base import BaseRepository, CreateSchema, UpdateSchema
 from ums.crud.group.validation import GroupValidator
@@ -60,7 +60,7 @@ class CrudGroup(BaseRepository[Group]):
 
         Fetches a single Group record with the provided ID.
         """
-        return db.get(self.model, id)  # type: ignore
+        return super().get(db, id)  # type: ignore
 
     def get_by(
         self,
@@ -105,7 +105,7 @@ class CrudGroup(BaseRepository[Group]):
         for key, value in validated_group.items():
             setattr(db_obj, key, value)
 
-        setattr(db_obj, "updated_at", datetime.utcnow())
+        setattr(db_obj, "updated_at", datetime.now(tz=UTC))
 
         db.add(db_obj)
         db.commit()

--- a/ums/crud/user/repository.py
+++ b/ums/crud/user/repository.py
@@ -2,7 +2,7 @@ from typing import Type, Any
 from sqlmodel import Session
 import uuid
 from enum import Enum
-from datetime import datetime
+from datetime import datetime, UTC
 
 from ums.core.security import get_password_hash
 from ums.crud.base import BaseRepository, CreateSchema, UpdateSchema
@@ -112,7 +112,7 @@ class UserRepository(BaseRepository[User]):
         if validated_user.get("password"):
             validated_user["password"] = get_password_hash(validated_user["password"])
 
-        update_datetime = datetime.utcnow()
+        update_datetime = datetime.now(tz=UTC)
 
         for key, value in validated_user.items():
             setattr(db_obj, key, value)

--- a/ums/crud/user/repository.py
+++ b/ums/crud/user/repository.py
@@ -2,7 +2,15 @@ from typing import Type, Any
 from sqlmodel import Session
 import uuid
 from enum import Enum
-from datetime import datetime, UTC
+import sys
+from datetime import datetime
+
+if sys.version_info > (3, 11):
+    from datetime import UTC
+else:
+    from datetime import timezone
+
+    UTC = timezone.utc
 
 from ums.core.security import get_password_hash
 from ums.crud.base import BaseRepository, CreateSchema, UpdateSchema

--- a/ums/models.py
+++ b/ums/models.py
@@ -1,5 +1,5 @@
 from typing import Any
-from datetime import datetime
+from datetime import datetime, UTC
 from sqlmodel import Field, Relationship, SQLModel
 import uuid
 
@@ -9,8 +9,8 @@ import uuid
 
 class Base(SQLModel):
     id: Any
-    created_at: datetime = Field(default_factory=datetime.utcnow)
-    updated_at: datetime = Field(default_factory=datetime.utcnow)
+    created_at: datetime = Field(default=datetime.now(tz=UTC))
+    updated_at: datetime = Field(default=datetime.now(tz=UTC))
     deleted_at: datetime | None = None
 
 

--- a/ums/models.py
+++ b/ums/models.py
@@ -1,5 +1,14 @@
 from typing import Any
-from datetime import datetime, UTC
+import sys
+from datetime import datetime
+
+if sys.version_info > (3, 11):
+    from datetime import UTC
+else:
+    from datetime import timezone
+
+    UTC = timezone.utc
+
 from sqlmodel import Field, Relationship, SQLModel
 import uuid
 


### PR DESCRIPTION
## 📝 Description

MR changes replace naive datetime objects with UTC time zone aware ones.

## 💼 Type of change

- [X] Maintenance

## 📋 Related ticket(s)

Closes https://github.com/daconjurer/ums/issues/9

📌 Additional comments

N/A