### PR TITLE
enhancement: Fix OpenAPI schema so that clients can be generated

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+plugins = pydantic.mypy

--- a/poetry.lock
+++ b/poetry.lock
@@ -594,44 +594,44 @@ dev = ["Sphinx (==7.2.5)", "colorama (==0.4.5)", "colorama (==0.4.6)", "exceptio
 
 [[package]]
 name = "mypy"
-version = "1.8.0"
+version = "1.11.1"
 description = "Optional static typing for Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "mypy-1.8.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:485a8942f671120f76afffff70f259e1cd0f0cfe08f81c05d8816d958d4577d3"},
-    {file = "mypy-1.8.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:df9824ac11deaf007443e7ed2a4a26bebff98d2bc43c6da21b2b64185da011c4"},
-    {file = "mypy-1.8.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2afecd6354bbfb6e0160f4e4ad9ba6e4e003b767dd80d85516e71f2e955ab50d"},
-    {file = "mypy-1.8.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:8963b83d53ee733a6e4196954502b33567ad07dfd74851f32be18eb932fb1cb9"},
-    {file = "mypy-1.8.0-cp310-cp310-win_amd64.whl", hash = "sha256:e46f44b54ebddbeedbd3d5b289a893219065ef805d95094d16a0af6630f5d410"},
-    {file = "mypy-1.8.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:855fe27b80375e5c5878492f0729540db47b186509c98dae341254c8f45f42ae"},
-    {file = "mypy-1.8.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4c886c6cce2d070bd7df4ec4a05a13ee20c0aa60cb587e8d1265b6c03cf91da3"},
-    {file = "mypy-1.8.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d19c413b3c07cbecf1f991e2221746b0d2a9410b59cb3f4fb9557f0365a1a817"},
-    {file = "mypy-1.8.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:9261ed810972061388918c83c3f5cd46079d875026ba97380f3e3978a72f503d"},
-    {file = "mypy-1.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:51720c776d148bad2372ca21ca29256ed483aa9a4cdefefcef49006dff2a6835"},
-    {file = "mypy-1.8.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:52825b01f5c4c1c4eb0db253ec09c7aa17e1a7304d247c48b6f3599ef40db8bd"},
-    {file = "mypy-1.8.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f5ac9a4eeb1ec0f1ccdc6f326bcdb464de5f80eb07fb38b5ddd7b0de6bc61e55"},
-    {file = "mypy-1.8.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:afe3fe972c645b4632c563d3f3eff1cdca2fa058f730df2b93a35e3b0c538218"},
-    {file = "mypy-1.8.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:42c6680d256ab35637ef88891c6bd02514ccb7e1122133ac96055ff458f93fc3"},
-    {file = "mypy-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:720a5ca70e136b675af3af63db533c1c8c9181314d207568bbe79051f122669e"},
-    {file = "mypy-1.8.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:028cf9f2cae89e202d7b6593cd98db6759379f17a319b5faf4f9978d7084cdc6"},
-    {file = "mypy-1.8.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:4e6d97288757e1ddba10dd9549ac27982e3e74a49d8d0179fc14d4365c7add66"},
-    {file = "mypy-1.8.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7f1478736fcebb90f97e40aff11a5f253af890c845ee0c850fe80aa060a267c6"},
-    {file = "mypy-1.8.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:42419861b43e6962a649068a61f4a4839205a3ef525b858377a960b9e2de6e0d"},
-    {file = "mypy-1.8.0-cp38-cp38-win_amd64.whl", hash = "sha256:2b5b6c721bd4aabaadead3a5e6fa85c11c6c795e0c81a7215776ef8afc66de02"},
-    {file = "mypy-1.8.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:5c1538c38584029352878a0466f03a8ee7547d7bd9f641f57a0f3017a7c905b8"},
-    {file = "mypy-1.8.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:4ef4be7baf08a203170f29e89d79064463b7fc7a0908b9d0d5114e8009c3a259"},
-    {file = "mypy-1.8.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7178def594014aa6c35a8ff411cf37d682f428b3b5617ca79029d8ae72f5402b"},
-    {file = "mypy-1.8.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:ab3c84fa13c04aeeeabb2a7f67a25ef5d77ac9d6486ff33ded762ef353aa5592"},
-    {file = "mypy-1.8.0-cp39-cp39-win_amd64.whl", hash = "sha256:99b00bc72855812a60d253420d8a2eae839b0afa4938f09f4d2aa9bb4654263a"},
-    {file = "mypy-1.8.0-py3-none-any.whl", hash = "sha256:538fd81bb5e430cc1381a443971c0475582ff9f434c16cd46d2c66763ce85d9d"},
-    {file = "mypy-1.8.0.tar.gz", hash = "sha256:6ff8b244d7085a0b425b56d327b480c3b29cafbd2eff27316a004f9a7391ae07"},
+    {file = "mypy-1.11.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:a32fc80b63de4b5b3e65f4be82b4cfa362a46702672aa6a0f443b4689af7008c"},
+    {file = "mypy-1.11.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c1952f5ea8a5a959b05ed5f16452fddadbaae48b5d39235ab4c3fc444d5fd411"},
+    {file = "mypy-1.11.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e1e30dc3bfa4e157e53c1d17a0dad20f89dc433393e7702b813c10e200843b03"},
+    {file = "mypy-1.11.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:2c63350af88f43a66d3dfeeeb8d77af34a4f07d760b9eb3a8697f0386c7590b4"},
+    {file = "mypy-1.11.1-cp310-cp310-win_amd64.whl", hash = "sha256:a831671bad47186603872a3abc19634f3011d7f83b083762c942442d51c58d58"},
+    {file = "mypy-1.11.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:7b6343d338390bb946d449677726edf60102a1c96079b4f002dedff375953fc5"},
+    {file = "mypy-1.11.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e4fe9f4e5e521b458d8feb52547f4bade7ef8c93238dfb5bbc790d9ff2d770ca"},
+    {file = "mypy-1.11.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:886c9dbecc87b9516eff294541bf7f3655722bf22bb898ee06985cd7269898de"},
+    {file = "mypy-1.11.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:fca4a60e1dd9fd0193ae0067eaeeb962f2d79e0d9f0f66223a0682f26ffcc809"},
+    {file = "mypy-1.11.1-cp311-cp311-win_amd64.whl", hash = "sha256:0bd53faf56de9643336aeea1c925012837432b5faf1701ccca7fde70166ccf72"},
+    {file = "mypy-1.11.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:f39918a50f74dc5969807dcfaecafa804fa7f90c9d60506835036cc1bc891dc8"},
+    {file = "mypy-1.11.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0bc71d1fb27a428139dd78621953effe0d208aed9857cb08d002280b0422003a"},
+    {file = "mypy-1.11.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b868d3bcff720dd7217c383474008ddabaf048fad8d78ed948bb4b624870a417"},
+    {file = "mypy-1.11.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:a707ec1527ffcdd1c784d0924bf5cb15cd7f22683b919668a04d2b9c34549d2e"},
+    {file = "mypy-1.11.1-cp312-cp312-win_amd64.whl", hash = "sha256:64f4a90e3ea07f590c5bcf9029035cf0efeae5ba8be511a8caada1a4893f5525"},
+    {file = "mypy-1.11.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:749fd3213916f1751fff995fccf20c6195cae941dc968f3aaadf9bb4e430e5a2"},
+    {file = "mypy-1.11.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:b639dce63a0b19085213ec5fdd8cffd1d81988f47a2dec7100e93564f3e8fb3b"},
+    {file = "mypy-1.11.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4c956b49c5d865394d62941b109728c5c596a415e9c5b2be663dd26a1ff07bc0"},
+    {file = "mypy-1.11.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:45df906e8b6804ef4b666af29a87ad9f5921aad091c79cc38e12198e220beabd"},
+    {file = "mypy-1.11.1-cp38-cp38-win_amd64.whl", hash = "sha256:d44be7551689d9d47b7abc27c71257adfdb53f03880841a5db15ddb22dc63edb"},
+    {file = "mypy-1.11.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:2684d3f693073ab89d76da8e3921883019ea8a3ec20fa5d8ecca6a2db4c54bbe"},
+    {file = "mypy-1.11.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:79c07eb282cb457473add5052b63925e5cc97dfab9812ee65a7c7ab5e3cb551c"},
+    {file = "mypy-1.11.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:11965c2f571ded6239977b14deebd3f4c3abd9a92398712d6da3a772974fad69"},
+    {file = "mypy-1.11.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a2b43895a0f8154df6519706d9bca8280cda52d3d9d1514b2d9c3e26792a0b74"},
+    {file = "mypy-1.11.1-cp39-cp39-win_amd64.whl", hash = "sha256:1a81cf05975fd61aec5ae16501a091cfb9f605dc3e3c878c0da32f250b74760b"},
+    {file = "mypy-1.11.1-py3-none-any.whl", hash = "sha256:0624bdb940255d2dd24e829d99a13cfeb72e4e9031f9492148f410ed30bcab54"},
+    {file = "mypy-1.11.1.tar.gz", hash = "sha256:f404a0b069709f18bbdb702eb3dcfe51910602995de00bd39cea3050b5772d08"},
 ]
 
 [package.dependencies]
 mypy-extensions = ">=1.0.0"
 tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
-typing-extensions = ">=4.1.0"
+typing-extensions = ">=4.6.0"
 
 [package.extras]
 dmypy = ["psutil (>=4.0)"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ums"
-version = "0.2.0"
+version = "0.3.0"
 description = "A general purpose user management system (UMS)"
 authors = ["Victor Sandoval <vs.software.eng@gmail.com>"]
 

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,15 +1,14 @@
 #! /bin/bash
 
 echo "ruff check --diff ums/ tests/ db/ && ruff check --select I --diff ums/ tests/ db/"
-ruff check --diff ums/ tests/ db/
-ruff check --select I --diff ums/ tests/ db/
+ruff check --diff ums/ tests/ db/ && ruff check --select I --diff ums/ tests/ db/
 if [ $? -ne 0 ]; then
     echo "Error: ruff check failed"
     exit 1
 fi
 echo "DONE!"
 
-echo "ruff format --diff ums/"
+echo "ruff format --diff ums/ tests/ db/"
 ruff format --diff ums/ tests/ db/
 if [ $? -ne 0 ]; then
     echo "Error: ruff format failed"
@@ -17,8 +16,8 @@ if [ $? -ne 0 ]; then
 fi
 echo "DONE!"
 
-echo "mypy ums/"
-mypy ums/
+echo "mypy ums/ tests/ db/"
+mypy ums/ tests/ db/
 if [ $? -ne 0 ]; then
     echo "Error: mypy failed"
     exit 1

--- a/tests/api/v1/test_auth.py
+++ b/tests/api/v1/test_auth.py
@@ -13,7 +13,7 @@ from tests.fixtures import (
 )
 
 
-class TestUserRoute:
+class TestLoginRoute:
     def setup_method(self):
         self.url = "/login"
 

--- a/tests/api/v1/test_user.py
+++ b/tests/api/v1/test_user.py
@@ -101,36 +101,10 @@ class TestUserRoute:
         payload = response.json()
 
         assert response.status_code == 200
-        assert initialized_users[test_user_number].name in payload[0]["name"]
-
-    def test_read_users_with_invalid_filtering(
-        self,
-        client: TestClient,  # noqa F811
-        initialized_users,  # noqa F811
-        initialized_admin,  # noqa F811
-    ):
-        # setup
-        current_user, current_user_role = initialized_admin
-        invalid_filter = "invalid:filter"
-
-        access_token_expires = timedelta(minutes=1)
-        user_scopes = [
-            permissions.name for permissions in current_user_role.permissions
-        ]
-        access_token = create_access_token(
-            data={"sub": current_user.name, "scopes": user_scopes},
-            expire_delta=access_token_expires,
+        assert (
+            initialized_users[test_user_number].name
+            in payload[test_user_number]["name"]
         )
-
-        # test
-        response = client.get(
-            url=self.url,
-            headers={"Authorization": f"Bearer {access_token}"},
-            params={"filter": invalid_filter},
-        )
-
-        # validation
-        assert response.status_code == 422
 
     def test_read_users_with_sorting(
         self,

--- a/tests/crud/test_group.py
+++ b/tests/crud/test_group.py
@@ -12,9 +12,9 @@ from tests.fixtures import (
     setup_and_teardown_db,  # noqa F401
 )
 from ums.core.exceptions import InvalidGroupException, InvalidUserException
-from ums.crud.group.repository import group_repository
+from ums.crud.base import SortParams
+from ums.crud.group.repository import GroupFilterParams, group_repository
 from ums.crud.group.schemas import GroupCreate, GroupUpdate
-from ums.middlewares.filter_sort import FilterBy, SortBy, SortOptions
 
 
 class TestGroupRepository:
@@ -97,7 +97,7 @@ class TestGroupRepository:
         # Test
         stored_object = self.test_group_repository.get_by(
             db=self.test_db,
-            filter=FilterBy(key="name", value=created_group.name),
+            filter=GroupFilterParams(name=created_group.name),
         )
 
         # Validation
@@ -114,7 +114,7 @@ class TestGroupRepository:
         # Test
         stored_object = self.test_group_repository.get_by(
             db=self.test_db,
-            filter=FilterBy(key="title", value="Mr"),
+            filter=GroupFilterParams(title="Mr"),
         )
 
         # Validation
@@ -130,11 +130,11 @@ class TestGroupRepository:
         # Test
         stored_objects = self.test_group_repository.get_many(
             db=self.test_db,
-            filter=[
-                FilterBy(key="location", value="Glasgow"),
-                FilterBy(key="is_active", value="true"),
-            ],
-            sort=SortBy(key="created_at", by=SortOptions.asc),
+            filter=GroupFilterParams(
+                location="Glasgow",
+                is_active="true",
+            ),
+            sort=SortParams(sort_by="created_at", sort_order="asc"),
         )
 
         # Validation

--- a/ums/api/v1/controllers/permissions.py
+++ b/ums/api/v1/controllers/permissions.py
@@ -1,14 +1,18 @@
 from typing import Sequence
 from uuid import UUID
 
+from fastapi import Depends
+from typing_extensions import Annotated
+
 from ums.crud.permissions.repository import permissions_repository
-from ums.db.session import get_session
+from ums.db.session import Session, get_session
 from ums.models import Permissions
 
 
-def get_permissions_by_role_id(role_id: UUID) -> Sequence[Permissions]:
+def get_permissions_by_role_id(
+    role_id: UUID,
+    db: Annotated[Session, Depends(get_session)],
+) -> Sequence[Permissions]:
     """Get the permissions of a role."""
-    permissions = permissions_repository.get_by_role_id(
-        db=next(get_session()), role_id=role_id
-    )
+    permissions = permissions_repository.get_by_role_id(db=db, role_id=role_id)
     return permissions

--- a/ums/api/v1/controllers/user.py
+++ b/ums/api/v1/controllers/user.py
@@ -2,8 +2,8 @@ from uuid import UUID
 
 from pydantic import BaseModel, EmailStr
 
-from ums.crud.user.repository import FilterBy, user_repository
-from ums.db.session import get_session
+from ums.crud.user.repository import User, UserFilterParams, user_repository
+from ums.db.session import Session
 
 
 class UserPublic(BaseModel):
@@ -23,19 +23,19 @@ def get_user_public_info(user) -> UserPublic:
     return public_user_info
 
 
-def get_user_by_name(name: str):
+def get_user_by_name(name: str, db: Session) -> User | None:
     user = user_repository.get_by(
-        db=next(get_session()),
-        filter=FilterBy(key="name", value=name),
+        db=db,
+        filter=UserFilterParams(name=name),
     )
     return user
 
 
-def get_user_role_id(name: str) -> UUID | None:
+def get_user_role_id(name: str, db: Session) -> UUID | None:
     """Get the role_id of a user."""
     user = user_repository.get_by(
-        db=next(get_session()),
-        filter=FilterBy(key="name", value=name),
+        db=db,
+        filter=UserFilterParams(name=name),
     )
     if user:
         return user.role_id

--- a/ums/api/v1/routes/user.py
+++ b/ums/api/v1/routes/user.py
@@ -4,9 +4,14 @@ from fastapi import APIRouter, Depends, Query, Security
 
 from ums.api.v1.controllers import user
 from ums.api.v1.controllers.auth import get_current_active_user
-from ums.crud.user.repository import UserFilterByEnum, UserSortByEnum, user_repository
-from ums.db.session import get_session
-from ums.middlewares.filter_sort import FilterBy, SortBy, parse_filter, parse_sort
+from ums.crud.user.repository import (
+    SortParams,
+    UserFilterParams,
+    UserSortOptions,
+    user_repository,
+)
+from ums.db.session import Session, get_session
+from ums.middlewares.filter_sort import parse_sorting
 from ums.models import User
 
 router = APIRouter(tags=["user"])
@@ -15,19 +20,16 @@ router = APIRouter(tags=["user"])
 @router.get("/users")
 async def read_users(
     current_user: Annotated[User, Security(get_current_active_user, scopes=["users"])],
-    filter: list[FilterBy] | None = Depends(
-        parse_filter([member.value for member in UserFilterByEnum])
-    ),
-    sort: SortBy | None = Depends(
-        parse_sort([member.value for member in UserSortByEnum])
-    ),
+    db: Session = Depends(get_session),
+    filter: UserFilterParams = Depends(),
+    sort: SortParams = Depends(parse_sorting(UserSortOptions)),
     limit: int = Query(10, ge=1, le=50),
     page: int = Query(1, ge=1),
 ) -> list[user.UserPublic]:
     users_public_info = []
 
     users_info = user_repository.get_many(
-        db=next(get_session()),
+        db=db,
         filter=filter,
         sort=sort,
         limit=limit,

--- a/ums/settings/api.py
+++ b/ums/settings/api.py
@@ -4,5 +4,7 @@ from ums.settings.base import CommonSettings
 
 
 class APISettings(CommonSettings):
-    api_host: IPvAnyAddress = Field(validation_alias="API_HOST", default="0.0.0.0")
+    api_host: IPvAnyAddress = Field(
+        validation_alias="API_HOST", default=IPvAnyAddress("0.0.0.0")
+    )
     api_port: int = Field(validation_alias="API_PORT", default=3000)


### PR DESCRIPTION
## 📝 Description

MR improves the filtering and sorting dependencies implementation. Previously the approach followed to accomplish filtering and sorting did not allow to create a schema fully typed. When interacting with other OpenAPI clients, especially frontend ones, automatic type generation was not possible.

- Introduces a `BaseFilterParams` class to allow splitting and typing each of the filter parameters when implementing it.
- Introduces a `SortParams` class that together with subclasses of `str` and `Enum` allow generating concrete `SortOptions` literal types.
- These are exposed and shown in the docs using FastAPI's `Query`.

### 💼 Type of change

- [X] Enhancement
- [X] Tests

### 📋 Related ticket(s)

- Closes #26 

### 📌 Additional comments

Using a package like [@hey-api/openapi-ts](https://github.com/hey-api/openapi-ts), the TypeScript types and services for interacting with the API can be generated. For instance, running locally:

`openapi-ts -i http://127.0.0.1:8000/openapi.json -o src/services/apis/ums`